### PR TITLE
Allows some additional options to control the output of the CSS a bit more

### DIFF
--- a/src/Sprite.php
+++ b/src/Sprite.php
@@ -31,6 +31,9 @@ class Sprite
      */
     protected $options = [
         'exception_on_error' => 0,
+        'url' => '%url%',
+        'root_class' => 'sprite',
+        'class_prefix' => 'sprite',
         'algorithm' => 'area', // area, point
     ];
 
@@ -309,9 +312,9 @@ class Sprite
         unset($canvas, $imagick);
 
         // style
-        $this->style = ".sprite {background-image: url(%url%);}\n";
+        $this->style = ".{$this->options['root_class']} {background-image: url({$this->options['url']});}\n";
         foreach ($this->files as $index => $file) {
-            $this->style.= ".sprite.sprite-".$index." {width: ".$file['w']."px; height: ".$file['h']."px; background-position: ".(0 - $file['x'])."px ".(0 - $file['y'])."px;}\n";
+            $this->style.= ".{$this->options['root_class']}.{$this->options['class_prefix']}-".$index." {width: ".$file['w']."px; height: ".$file['h']."px; background-position: ".(0 - $file['x'])."px ".(0 - $file['y'])."px;}\n";
         }
     }
 }


### PR DESCRIPTION
Simply adds a couple extra basic options to adjust what the generated CSS outputs

| Option  | Default | Purpose |
| ------------- | ------------- | ------------- |
| url  | "%url%"  | The default templatized url is good for replacing in real time, but if the user knows what the final URL of the image is going to wind up being, they can supply it |
| root_class | "sprite" | As there can be several sprite sheets per page, we can allow the user to componentize the specific sprite sheet root class |
| class_prefix | "sprite" | If the user wants to adjust what each sprite is referred to as, this option is for them |

Supplying this because I needed to adjust what the class names were called and instead of doing a str_replace on both `"sprite"` and `%url%` (especially in the case where an image name could contain the string `sprite`) figured it could just be available as options in the class instead.  